### PR TITLE
Use GITHUB_TOKEN

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,9 +37,9 @@ if [ -z ${GITHUB_EMAIL+x} ]; then
     read "GITHUB_EMAIL?Enter Github Email: "
     echo "GITHUB_EMAIL=${GITHUB_EMAIL}" >> $HOME/environment/environment.zsh
 fi
-if [ -z ${GITHUB_PAT+x} ]; then 
+if [ -z ${GITHUB_TOKEN+x} ]; then 
     read "GITHUB_PAT?Enter Github Peronal Access Token: "
-    echo "GITHUB_PAT=${GITHUB_PAT}" >> $HOME/environment/environment.zsh
+    echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $HOME/environment/environment.zsh
 fi
 
 # Create SSH Key
@@ -71,12 +71,15 @@ brew_in_path
 # Add SSH Key to Github Account
 brew install gh
 # Get Serial Number
+set -x 
 serial_number=$(system_profiler SPHardwareDataType | grep Serial | sed 's/^.*: //')
 public_key=$(cat $HOME/.ssh/id_ed25519.pub)
-echo "$GITHUB_PAT" | gh auth login --with-token -p ssh -h github.com
+export GITHUB_TOKEN="${GITHUB_TOKEN}"
+gh auth login -p ssh -h github.com > /dev/null
 if ! gh ssh-key list | grep -q "${public_key:0:50}"; then 
     gh ssh-key add -t "$(hostname)-${serial_number}" $HOME/.ssh/id_ed25519.pub || true
 fi
+set +x
 
 DOTFILES_REPO=${DOTFILES_REPO:-airtasker\/dotfiles.git}
 if [[ ! -d $HOME/dotfiles ]]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,7 +38,7 @@ if [ -z ${GITHUB_EMAIL+x} ]; then
     echo "GITHUB_EMAIL=${GITHUB_EMAIL}" >> $HOME/environment/environment.zsh
 fi
 if [ -z ${GITHUB_TOKEN+x} ]; then 
-    read "GITHUB_PAT?Enter Github Peronal Access Token: "
+    read "GITHUB_TOKEN?Enter Github Peronal Access Token: "
     echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $HOME/environment/environment.zsh
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,7 +71,6 @@ brew_in_path
 # Add SSH Key to Github Account
 brew install gh
 # Get Serial Number
-set -x 
 serial_number=$(system_profiler SPHardwareDataType | grep Serial | sed 's/^.*: //')
 public_key=$(cat $HOME/.ssh/id_ed25519.pub)
 export GITHUB_TOKEN="${GITHUB_TOKEN}"
@@ -79,7 +78,6 @@ gh auth login -p ssh -h github.com > /dev/null
 if ! gh ssh-key list | grep -q "${public_key:0:50}"; then 
     gh ssh-key add -t "$(hostname)-${serial_number}" $HOME/.ssh/id_ed25519.pub || true
 fi
-set +x
 
 DOTFILES_REPO=${DOTFILES_REPO:-airtasker\/dotfiles.git}
 if [[ ! -d $HOME/dotfiles ]]; then


### PR DESCRIPTION
### WHY
* Error handle ```gh``` cli already having a ```GITHUB_TOKEN``` variable

### WHAT
* use supported ```gh``` cli ```GITHUB_TOKEN```  instead of passing our own variable into the gh cli. 
* gh cli errors when it has the GITHUB_TOKEN already in the environment. So no reason to do this differently. 