### PR TITLE
[NOTICKET] Fix gh auth step as it will use expected variable

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,7 +74,7 @@ brew install gh
 serial_number=$(system_profiler SPHardwareDataType | grep Serial | sed 's/^.*: //')
 public_key=$(cat $HOME/.ssh/id_ed25519.pub)
 export GITHUB_TOKEN="${GITHUB_TOKEN}"
-gh auth login -p ssh -h github.com > /dev/null
+gh auth status > /dev/null
 if ! gh ssh-key list | grep -q "${public_key:0:50}"; then 
     gh ssh-key add -t "$(hostname)-${serial_number}" $HOME/.ssh/id_ed25519.pub || true
 fi


### PR DESCRIPTION
### WHY
To fix script from erroring

### WHAT
Updates the ```gh``` auth step to use the expected ```GITHUB_TOKEN``` value. 