### PR TITLE
[UPDATE]: Add `ssh-agent`  to zsh plugins array

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -94,6 +94,7 @@ plugins=(
     kubectl
     vscode
     z
+    ssh-agent
     zsh-autosuggestions
     zsh-syntax-highlighting
 )


### PR DESCRIPTION
#### WHY
- To allow engineers to only enter ssh passphrase only once on terminal start up

#### WHAT
- add ssh-agent to zsh plugin array