### PR TITLE
Update README.md - adds required Github token scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a quick guide to get your setup up and running!
       repo
       read:org
       write:public_key
+      admin:ssh_signing_key
       ```
     Althogh more permissions may be useful if you plan to use the ```gh``` cli for other functions      
 


### PR DESCRIPTION
Adds required permission to the readme.

Without this, the following error shows when running bootstrap.sh:

```sh
github.com
  ✓ Logged in to github.com as steverabino (GITHUB_TOKEN)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: ghp_************************************
  ✓ Token scopes: read:org, repo, write:public_key
warning:  HTTP 404: Not Found (https://api.github.com/user/ssh_signing_keys?per_page=100)
This API operation needs the "admin:ssh_signing_key" scope. To request it, run:  gh auth refresh -h github.com -s admin:ssh_signing_key
```