### PR TITLE
[NT] Remove homebrew/cask-drivers

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,7 +2,6 @@
 tap "homebrew/autoupdate"
 tap "homebrew/bundle"
 tap "homebrew/cask"
-tap "homebrew/cask-drivers"
 tap "homebrew/cask-fonts"
 tap "homebrew/cask-versions"
 tap "homebrew/core"


### PR DESCRIPTION
All homebrew/cask-drivers have now been [deleted or migrated into homebrew/cask](https://github.com/Homebrew/brew/pull/15535)

![image](https://github.com/airtasker/dotfiles/assets/4599695/b5e6d725-41cf-4e8a-bdbd-54bfb807cc59)
