### PR TITLE
Remove no longer working formulas from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,8 @@
 # essential_start_marker
 tap "homebrew/autoupdate"
 tap "homebrew/bundle"
-tap "homebrew/cask"
 tap "homebrew/cask-fonts"
 tap "homebrew/cask-versions"
-tap "homebrew/core"
 tap "homebrew/services"
 brew "ansible"
 brew "bash"


### PR DESCRIPTION
## WHY
Because the script is failing with these items

## WHAT
* Removes `homebrew/core` and `homebrew/cask` from the Brewfile