### PR TITLE
fix(brew): Remove deprecated taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,6 @@
 # essential_start_marker
 tap "homebrew/autoupdate"
 tap "homebrew/bundle"
-tap "homebrew/cask-fonts"
-tap "homebrew/cask-versions"
 tap "homebrew/services"
 brew "ansible"
 brew "bash"


### PR DESCRIPTION
## WHY
Because this is currently failing

## WHAT 
* Removes no longer working taps from Brewfile