### PR TITLE
Alias the required GITHUB_PACKAGES_TOKEN during dotfiles setup

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -63,6 +63,8 @@ if [[ -n "$input_token" ]]; then
     GITHUB_TOKEN="$input_token"
     sed -i '' '/^GITHUB_TOKEN=/d' $HOME/environment/environment.zsh
     echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $HOME/environment/environment.zsh
+    sed -i '' '/^GITHUB_PACKAGES_TOKEN=/d' $HOME/environment/environment.zsh
+    echo "GITHUB_PACKAGES_TOKEN=\$GITHUB_TOKEN" >> $HOME/environment/environment.zsh
 elif [[ -z "$current_token" ]]; then
     echo "ERROR: GITHUB_TOKEN is required"
     exit 1


### PR DESCRIPTION
`GITHUB_TOKEN` is required for Github CLI but our applications require the PAT to be set to `GITHUB_PACKAGES_TOKEN` this PR sets up both from the same value for a new starter

I don't quite understand why there is no `export` keyword in front of this but choosing to follow the convention here assuming the environment scripts require this? Feedback welcome 😂 