### PR TITLE
Add postgres plugin and Rails setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,30 @@ The bootstrap.sh sets up your mac for first use
 * It installs brew and then uses brew to install more tools found in ```Brewfile```. 
 * Creates new SSH key and uses the ```gh``` command line tool to add that key to your github account. (Script will prompt for Github Personal Access Token)
 * Installs the ```asdf``` version manager tool and also installs the latest version of these tools
-    * golang 
-    * kubectl 
-    * nodejs 
-    * python 
-    * ruby 
+    * golang
+    * kubectl
+    * nodejs
+    * pnpm (Node.js package manager)
+    * postgres (PostgreSQL client tools for Rails development)
+    * python
+    * ruby
     * terraform
 * Installs oh-my-zsh and powerlevel10k to make your terminal look great!
 * Installs NvChad to make your vim spectactular
-* Installs a great default tmux config 
+* Installs a great default tmux config
+
+### Rails Project Setup
+
+After running the bootstrap script, set up a Rails project with these commands:
+
+```bash
+cd your-rails-project
+asdf install                      # Install project-specific versions from .tool-versions
+setup_ruby_for_rails             # Configure bundler for pg gem and native extensions
+bundle install                   # Install gems
+```
+
+The `setup_ruby_for_rails` function automatically configures the `pg` gem to compile against asdf-installed PostgreSQL, preventing common native extension compilation errors. 
 
 ### Dotfiles Structure
 The dotfiles are powered by a tool called `stow`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -186,7 +186,7 @@ fi
 # Add default asdf plugins
 if [[ ! -f ~/.tool-versions ]]; then 
     # Install ASDF plugins and install latest packages by default
-    asdf_plugins=( golang kubectl nodejs pnpm python ruby terraform )
+    asdf_plugins=( golang kubectl nodejs pnpm postgres python ruby terraform )
     for p in "${asdf_plugins[@]}"; do
         if [[ ! -d $HOME/.asdf/plugins/$p ]]; then
             asdf plugin add $p

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -146,8 +146,10 @@ if [[ ! -d $HOME/.oh-my-zsh ]]; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended --keep-zshrc
 else
     # Update Oh My Zsh if already installed
-    if [[ $(command -v omz) ]]; then
-    	omz update
+    # Source Oh My Zsh first to make omz command available
+    if [[ -f $HOME/.oh-my-zsh/oh-my-zsh.sh ]]; then
+        source $HOME/.oh-my-zsh/oh-my-zsh.sh
+        omz update
     fi
 fi
 

--- a/environment/environment/dotfiles/functions.zsh
+++ b/environment/environment/dotfiles/functions.zsh
@@ -51,7 +51,7 @@ alias deploydiff="git log production..$(git_main_branch) --pretty=format:'%<(23)
 
 # Install asdf defaults
 install_asdf_defaults() {
-  asdf_plugins=( golang kubectl nodejs python ruby terraform )
+  asdf_plugins=( golang kubectl nodejs pnpm postgres python ruby terraform )
   for p in "${asdf_plugins[@]}"; do
       if [[ ! -d $HOME/.asdf/plugins/$p ]]; then
           asdf plugin add $p
@@ -80,4 +80,24 @@ function uninstall_nvchad() {
   rm -rf ~/.config/nvim
   rm -rf ~/.local/share/nvim
   rm -rf ~/.cache/nvim
+}
+
+# Configure Ruby for Rails development (pg gem, bundler settings)
+function setup_ruby_for_rails() {
+  echo "Configuring bundler for native extensions..."
+
+  # Check if postgres is installed via asdf
+  if asdf where postgres &>/dev/null; then
+    echo "✓ Configuring pg gem to use asdf postgres"
+    bundle config build.pg --with-pg-config=$(asdf where postgres)/bin/pg_config
+  else
+    echo "⚠ Warning: postgres not found in asdf. Install with: asdf plugin add postgres && asdf install postgres latest"
+  fi
+
+  # Set common bundler configs
+  bundle config set --local path 'vendor/bundle'
+  bundle config set --local jobs 4
+
+  echo "✓ Ruby configured for Rails development"
+  echo "  Run 'bundle install' in your Rails project to install gems"
 }


### PR DESCRIPTION
## Summary

Run into some issues after bootstrap dotfiles and restart my RoR environment.

This PR adds PostgreSQL to the default asdf plugins and creates a helper function for Rails project setup.

## Changes

### 1. Add postgres to default asdf plugins
- Updated bootstrap.sh to include postgres in default plugin list
- Updated functions.zsh install_asdf_defaults() to include postgres and pnpm
- Ensures new engineers get PostgreSQL client tools automatically

### 2. New setup_ruby_for_rails() function
Creates a convenience function that:
- Configures bundler to use asdf-installed PostgreSQL for pg gem compilation
- Sets common bundler configs (vendor/bundle, parallel jobs)
- Provides clear error messages if postgres is missing

### 3. Documentation updates
- Updated README to list all default plugins (including pnpm and postgres)
- Added new "Rails Project Setup" section with setup commands
- Explains how to use the new helper function

## Motivation

The pg gem requires PostgreSQL client libraries to compile native extensions. Without postgres installed via asdf, engineers encounter errors like:

```
fatal error: 'libpq-fe.h' file not found
```

This PR prevents these errors by:
1. Installing postgres by default during bootstrap
2. Providing a simple setup_ruby_for_rails command to configure projects
3. Documenting the workflow in the README

## Testing

Tested on a fresh macOS setup:

```bash
# After bootstrap
cd rails-monolith
asdf install
setup_ruby_for_rails
bundle install  # Success! No pg gem errors
```

## Related

This complements recent rails-monolith README updates that document the same workflow from the project side.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
